### PR TITLE
Added cleanup to package.json to clean up old snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "webpack -d --watch",
     "build": "webpack --config webpack.prod.config.js",
     "heroku-postbuild": "webpack --config webpack.prod.config.js",
+    "cleanup": "rm -r client/__tests__/__snapshots__/",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
Now, to cleanup old snapshots, anyone can run:

npm run cleanup

and all the old snapshots are deleted.  If we are debugging an old component that was changed, it might be useful to have the old snapshot still there to compare with, so I don't want it to delete the snapshots every time tests run...