### PR TITLE
Add active view test

### DIFF
--- a/client/__tests__/ActiveComponent-test.js
+++ b/client/__tests__/ActiveComponent-test.js
@@ -1,0 +1,46 @@
+import 'jsdom-global/register'
+
+import React from 'react'
+import renderer from 'react-test-renderer'
+import {mount} from 'enzyme';
+
+import MainLayout from '../components/MainLayout'
+
+const FirstActiveView = () => {
+  return (
+    <p>First active view</p>
+  )
+}
+
+const SecondActiveView = () => {
+  return (
+    <p>Second active view</p>
+  )
+}
+
+test('Renders main layout', () => {
+  const tree = renderer.create(
+    <MainLayout
+      activeView={FirstActiveView}
+    />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Renders active views correctly', () => {
+  const firstTree = mount(
+    <MainLayout
+      activeView={FirstActiveView}
+    />
+  )
+
+  const secondTree = mount(
+    <MainLayout
+      activeView={SecondActiveView}
+    />
+  )
+
+  expect(firstTree).not.toBe(secondTree)
+  expect(firstTree.contains(<p>First active view</p>)).toBeTruthy()
+  expect(secondTree.contains(<p>Second active view</p>)).toBeTruthy()
+})

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
   },
   "devDependencies": {
     "jest": "^17.0.3",
+    "jsdom": "9.10.0",
+    "jsdom-global": "2.1.1",
     "react-native-babel-jest": "^0.2.0"
   }
 }


### PR DESCRIPTION
Tests `activeView` functionality of `MainLayout`.

Added `jsdom` as per [this issue](https://github.com/airbnb/enzyme/issues/341). Needed deep rendering to check the contents of `MainLayout`.